### PR TITLE
Fix geometry transformation assignment error

### DIFF
--- a/client/src/pages/MapView.tsx
+++ b/client/src/pages/MapView.tsx
@@ -590,7 +590,7 @@ export default function MapView() {
     const processCoordinate = (coord: number[]) => {
       if (!Array.isArray(coord) || coord.length < 2) return;
       
-      const [lng, lat] = coord;
+      let [lng, lat] = coord;
       if (!isFinite(lng) || !isFinite(lat)) return;
       
       // Since coordinates should already be transformed by transformSavedShapefileCoordinates,


### PR DESCRIPTION
Fixes "Assignment to constant variable" error by changing `const` to `let` for coordinate variables in `processCoordinate` to allow reassignment during transformation.

---
<a href="https://cursor.com/background-agent?bcId=bc-37a83a88-befe-4550-9270-028698cc8889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37a83a88-befe-4550-9270-028698cc8889">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>