### PR TITLE
Fix show recent shapefile button

### DIFF
--- a/client/src/pages/MapView.tsx
+++ b/client/src/pages/MapView.tsx
@@ -828,8 +828,15 @@ export default function MapView() {
   // Function to zoom to the most recent shapefile
   const zoomToRecentShapefile = () => {
     console.log('🔍 Attempting to zoom to recent shapefile...');
+    console.log('📊 Current state:', {
+      allShapefiles: allShapefiles.length,
+      localShapefiles: localShapefiles.length,
+      allShapefilesNames: allShapefiles.map(s => s.name),
+      localShapefilesNames: localShapefiles.map(s => s.name)
+    });
     
-    if (!allShapefiles || allShapefiles.length === 0) {
+    // Check if we have any shapefiles available (local or saved)
+    if ((!allShapefiles || allShapefiles.length === 0) && (!localShapefiles || localShapefiles.length === 0)) {
       console.warn('⚠️ No shapefiles available');
       toast({
         title: "No Shapefiles",
@@ -843,6 +850,13 @@ export default function MapView() {
     const recentShapefile = localShapefiles.length > 0 
       ? localShapefiles[localShapefiles.length - 1]
       : allShapefiles[allShapefiles.length - 1];
+    
+    console.log('🎯 Selected recent shapefile:', {
+      name: recentShapefile.name,
+      source: localShapefiles.length > 0 ? 'local' : 'saved',
+      id: recentShapefile._id
+    });
+    
     zoomToShapefile(recentShapefile);
   };
 
@@ -1154,7 +1168,7 @@ export default function MapView() {
             {/* Left side controls */}
             <div className="flex gap-2">
               {/* Show Recent Shapefile Button */}
-              {allShapefiles.length > 0 && (
+              {(allShapefiles.length > 0 || localShapefiles.length > 0) && (
                 <button
                   onClick={zoomToRecentShapefile}
                   className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1.5 rounded-md shadow-lg flex items-center gap-1 text-xs font-medium transition-colors"
@@ -1182,7 +1196,7 @@ export default function MapView() {
             {/* Left side buttons - Desktop */}
             <div className="absolute top-4 left-4 z-10 flex gap-2">
               {/* Show Recent Shapefile Button - Desktop */}
-              {allShapefiles.length > 0 && (
+              {(allShapefiles.length > 0 || localShapefiles.length > 0) && (
                 <button
                   onClick={zoomToRecentShapefile}
                   className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md shadow-lg flex items-center gap-2 text-sm font-medium transition-colors"


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes the "show recent shapefile" button to correctly display and zoom to the most recent shapefile, whether local or saved.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The button's visibility condition and the logic for selecting the "most recent" shapefile were inconsistent, primarily checking `allShapefiles` but prioritizing `localShapefiles` in the zoom logic. This led to the button not appearing or not functioning as expected when only local shapefiles were present. The fix updates the visibility to consider both `allShapefiles` and `localShapefiles` and refines the selection logic. Debugging logs have also been added for better insight.

---
<a href="https://cursor.com/background-agent?bcId=bc-52fbe0ea-a8f4-4c00-8557-55781ace59b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-52fbe0ea-a8f4-4c00-8557-55781ace59b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>