### PR TITLE
Debug script injection and component errors

### DIFF
--- a/client/src/components/CreateFeatureModal.tsx
+++ b/client/src/components/CreateFeatureModal.tsx
@@ -339,8 +339,8 @@ export default function CreateFeatureModal({
                 <FormItem>
                   <FormLabel>Feature Type</FormLabel>
                   <Select
-                    onValueChange={field.onChange}
-                    value={field.value}
+                    onValueChange={field?.onChange}
+                    value={field?.value || ""}
                   >
                     <FormControl>
                       <SelectTrigger>
@@ -394,8 +394,8 @@ export default function CreateFeatureModal({
                 <FormItem>
                   <FormLabel>{feaType} Type</FormLabel>
                   <Select
-                    onValueChange={field.onChange}
-                    value={field.value}
+                    onValueChange={field?.onChange}
+                    value={field?.value || ""}
                     key={feaType} // Force re-render when feature type changes
                   >
                     <FormControl>

--- a/client/src/components/ui/form.tsx
+++ b/client/src/components/ui/form.tsx
@@ -52,6 +52,10 @@ const useFormField = () => {
     throw new Error("useFormField should be used within <FormField>")
   }
 
+  if (!itemContext) {
+    throw new Error("useFormField should be used within <FormItem>")
+  }
+
   const { id } = itemContext
 
   return {

--- a/client/src/components/ui/form.tsx
+++ b/client/src/components/ui/form.tsx
@@ -46,8 +46,6 @@ const useFormField = () => {
   const itemContext = React.useContext(FormItemContext)
   const { getFieldState, formState } = useFormContext()
 
-  const fieldState = getFieldState(fieldContext.name, formState)
-
   if (!fieldContext) {
     throw new Error("useFormField should be used within <FormField>")
   }
@@ -55,6 +53,8 @@ const useFormField = () => {
   if (!itemContext) {
     throw new Error("useFormField should be used within <FormItem>")
   }
+
+  const fieldState = getFieldState(fieldContext.name, formState)
 
   const { id } = itemContext
 


### PR DESCRIPTION
Add null checks to form field handling to prevent destructuring errors.

The error "Cannot destructure property 'value' of '(intermediate value)' as it is null" was occurring when navigating to the map page via the "View on Map" button. This was due to `itemContext` being null in `useFormField` and `field.value`/`field.onChange` being accessed directly without null checks in `CreateFeatureModal`, leading to runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-af815d99-b76a-43b2-b889-ed738683a985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af815d99-b76a-43b2-b889-ed738683a985">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>