### PR TITLE
Fix map navigation and setLocation error

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ import { Trash2, MapPin, Users } from 'lucide-react';
 // Boundary Management Component
 function BoundaryManagement() {
   const { toast } = useToast();
+  const [, setLocation] = useLocation();
   const { data: boundaries = [], isLoading } = useQuery({
     queryKey: ['/api/boundaries'],
     queryFn: getAllBoundaries


### PR DESCRIPTION
Add `useLocation` hook to `BoundaryManagement` component to fix 'View on Map' navigation.

The `setLocation is not defined` error occurred because the `BoundaryManagement` component was attempting to use `setLocation` without importing the `useLocation` hook, which was only available in the parent `Dashboard` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d140468-0128-4a7a-bf30-69c5963b585a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d140468-0128-4a7a-bf30-69c5963b585a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>