### PR TITLE
Changes from background agent bc-d873b22e-9a8a-4521-9153-6a46ca0dcdc9

### DIFF
--- a/client/src/pages/MapView.tsx
+++ b/client/src/pages/MapView.tsx
@@ -195,7 +195,7 @@ export default function MapView() {
       
       attemptBoundaryNavigation();
     }
-  }, [mapMethods, features, boundaries]);
+  }, [mapMethods, features.length, boundaries.length]);
 
   // Handle map navigation errors
   useEffect(() => {


### PR DESCRIPTION
Fix infinite loop in MapView navigation effect by updating useEffect dependencies.

The `features` and `boundaries` arrays, sourced from React Query, were causing the `useEffect` to re-run infinitely because their references changed on every render, even if their content remained the same. Changing the dependencies to `features.length` and `boundaries.length` ensures the effect only triggers when the actual data count changes, resolving the loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-d873b22e-9a8a-4521-9153-6a46ca0dcdc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d873b22e-9a8a-4521-9153-6a46ca0dcdc9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>