### PR TITLE
Investigate map navigation hang on dashboard

### DIFF
--- a/client/src/pages/MapView.tsx
+++ b/client/src/pages/MapView.tsx
@@ -269,7 +269,7 @@ export default function MapView() {
     if (mapMethods && (features.length > 0 || boundaries.length > 0)) {
       handleUrlNavigation();
     }
-  }, [mapMethods, features, boundaries, handleUrlNavigation]);
+  }, [mapMethods, features.length, boundaries.length]);
 
   // Cleanup navigation timeout on unmount
   useEffect(() => {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes page hanging issue in MapView by resolving a `useEffect` dependency cycle.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `useEffect` was re-triggering infinitely because `handleUrlNavigation` (a `useCallback` depending on `features.length` and `boundaries.length`) was included in its dependencies, and `features`/`boundaries` arrays were recreated on every render. Changing dependencies to `features.length` and `boundaries.length` ensures the effect only runs when the actual data counts change, not just object references.

---
<a href="https://cursor.com/background-agent?bcId=bc-825ca5f1-b848-4855-8e23-e70f156a1f23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-825ca5f1-b848-4855-8e23-e70f156a1f23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>