### PR TITLE
Investigate dashboard page hang on map view

### DIFF
--- a/client/src/pages/MapView.tsx
+++ b/client/src/pages/MapView.tsx
@@ -141,6 +141,7 @@ export default function MapView() {
         
         // Only show error if URL parameters still exist (navigation didn't succeed)
         if (stillHasFeature || stillHasBoundary) {
+          console.log('⚠️ Navigation timeout - showing error message');
           toast({
             title: "Navigation Failed",
             description: "Unable to locate the selected item on the map. Please try again or check if the item still exists.",
@@ -152,6 +153,9 @@ export default function MapView() {
           if (stillHasFeature) newUrl.searchParams.delete('feature');
           if (stillHasBoundary) newUrl.searchParams.delete('boundary');
           window.history.replaceState({}, '', newUrl.toString());
+          
+          // Clear navigation tracking
+          navigationAttemptedRef.current.clear();
         }
       }, 10000); // 10 second timeout
     }
@@ -262,7 +266,7 @@ export default function MapView() {
         activeNavigationRef.current.delete(navigationKey);
       }
     }, 500); // 500ms debounce
-  }, [mapMethods, toast]); // Include necessary dependencies
+  }, []); // Remove dependencies to prevent infinite loops
 
   // Handle URL parameters for navigation - trigger when essential dependencies change
   useEffect(() => {
@@ -278,6 +282,7 @@ export default function MapView() {
     // 3. URL parameters have changed since last check
     if ((featureId || boundaryId) && mapMethods) {
       if (currentUrlParams !== lastUrlParamsRef.current) {
+        console.log('🔄 URL parameters changed, triggering navigation');
         lastUrlParamsRef.current = currentUrlParams;
         handleUrlNavigation();
       }
@@ -285,7 +290,7 @@ export default function MapView() {
       // Clear the last URL params if no parameters exist
       lastUrlParamsRef.current = '';
     }
-  }, [mapMethods, handleUrlNavigation]);
+  }, [mapMethods]); // Simplified dependency array
 
   // Monitor data changes and retry navigation if needed
   useEffect(() => {
@@ -300,12 +305,14 @@ export default function MapView() {
       
       // Check if navigation was attempted but failed, and now we have data
       if (featureId && features.length > 0 && !navigationAttemptedRef.current.has(featureKey)) {
+        console.log('🔄 Retrying feature navigation after data loaded');
         handleUrlNavigation();
       } else if (boundaryId && boundaries.length > 0 && !navigationAttemptedRef.current.has(boundaryKey)) {
+        console.log('🔄 Retrying boundary navigation after data loaded');
         handleUrlNavigation();
       }
     }
-  }, [features.length, boundaries.length, mapMethods, handleUrlNavigation]);
+  }, [features.length, boundaries.length, mapMethods]); // Simplified dependency array
 
   // Cleanup navigation timeout on unmount
   useEffect(() => {


### PR DESCRIPTION
Refactor MapView navigation logic to prevent page hanging by resolving infinite re-renders and race conditions.

The previous implementation of `handleUrlNavigation` and related `useEffect` hooks created circular dependencies and infinite re-render loops, causing the page to freeze when attempting to navigate to map features or boundaries. This PR simplifies dependencies and ensures navigation attempts are properly managed.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5ea4085-5541-4f6a-a27b-8289df86d51c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5ea4085-5541-4f6a-a27b-8289df86d51c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>