### PR TITLE
Fix image upload functionality

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -130,12 +130,12 @@ export async function getMyTasks() {
   return await res.json();
 }
 
-export async function updateTaskStatus(taskId: number, status: string) {
+export async function updateTaskStatus(taskId: string, status: string) {
   const res = await apiRequest('PUT', `/api/tasks/${taskId}/status`, { status });
   return await res.json();
 }
 
-export async function assignTask(taskId: number, assignedTo: number) {
+export async function assignTask(taskId: string, assignedTo: number) {
   const res = await apiRequest('PUT', `/api/tasks/${taskId}/assign`, { assignedTo });
   return await res.json();
 }
@@ -146,7 +146,7 @@ export async function deleteTask(taskId: string) {
 }
 
 // Task Updates API
-export async function createTaskUpdate(taskId: number, comment: string, oldStatus?: string, newStatus?: string) {
+export async function createTaskUpdate(taskId: string, comment: string, oldStatus?: string, newStatus?: string) {
   const res = await apiRequest('POST', `/api/tasks/${taskId}/updates`, {
     comment,
     oldStatus,
@@ -155,13 +155,13 @@ export async function createTaskUpdate(taskId: number, comment: string, oldStatu
   return await res.json();
 }
 
-export async function getTaskUpdates(taskId: number) {
+export async function getTaskUpdates(taskId: string) {
   const res = await apiRequest('GET', `/api/tasks/${taskId}/updates`);
   return await res.json();
 }
 
 // Task Evidence API
-export async function addTaskEvidence(taskId: number, formData: FormData) {
+export async function addTaskEvidence(taskId: string, formData: FormData) {
   // Use fetch directly for file uploads
   const res = await fetch(`/api/tasks/${taskId}/evidence`, {
     method: 'POST',
@@ -176,7 +176,7 @@ export async function addTaskEvidence(taskId: number, formData: FormData) {
   return await res.json();
 }
 
-export async function getTaskEvidence(taskId: number) {
+export async function getTaskEvidence(taskId: string) {
   const res = await apiRequest('GET', `/api/tasks/${taskId}/evidence`);
   return await res.json();
 }


### PR DESCRIPTION
Fix image upload on tasks by correcting `taskId` type in client API functions from number to string.

The `task._id` from MongoDB is an `ObjectId` which is converted to a string (`.toString()`) on the client side. However, the client-side API functions were incorrectly typed to expect a `number` for `taskId`, while the server routes correctly expect a `string`. This mismatch prevented image uploads from working.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcc822c6-6592-4060-a643-f5cc996d24c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcc822c6-6592-4060-a643-f5cc996d24c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

