### PR TITLE
Diagnose and fix boundary navigation

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -151,8 +151,10 @@ export default function Dashboard() {
   // When tab changes, update the URL query param (without reloading)
   useEffect(() => {
     const url = new URL(window.location.href);
-    url.searchParams.set('tab', activeTab);
-    window.history.replaceState({}, '', url.toString());
+    if (url.searchParams.get('tab') !== activeTab) {
+      url.searchParams.set('tab', activeTab);
+      window.history.replaceState({}, '', url.toString());
+    }
   }, [activeTab]);
 
   const { data: tasks = [] } = useQuery({ queryKey: ['/api/tasks'] });
@@ -412,7 +414,7 @@ export default function Dashboard() {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => setLocation(`/map?feature=${boundary._id}`)}
+                          onClick={() => setLocation(`/map?boundary=${boundary._id}`)}
                           className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
                         >
                           <MapPin className="h-4 w-4 mr-1" />

--- a/client/src/pages/FeatureList.tsx
+++ b/client/src/pages/FeatureList.tsx
@@ -225,7 +225,7 @@ export default function FeatureList() {
                     <Button 
                       variant="outline" 
                       size="sm"
-                      onClick={() => setLocation(`/map?feature=${feature._id}`)}
+                      onClick={() => setLocation(`/map?${feature.feaType === 'Parcel' ? 'boundary' : 'feature'}=${feature._id}`)}
                       className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
                     >
                       <MapPin className="h-4 w-4 mr-1" />


### PR DESCRIPTION
Fixes boundary navigation by using correct URL parameters and reduces browser throttling by preventing redundant history updates.

Previously, 'View on Map' links for Parcel boundaries incorrectly used `?feature=` instead of `?boundary=`, causing navigation issues. Additionally, the Dashboard tab's URL syncing frequently called `window.history.replaceState` even when the tab parameter hadn't changed, leading to Chrome's navigation throttling warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-b30e62ae-f748-42d2-a647-a5df0482ade4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b30e62ae-f748-42d2-a647-a5df0482ade4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

