### PR TITLE
Fix map view navigation interference with dashboard

### DIFF
--- a/client/src/pages/MapView.tsx
+++ b/client/src/pages/MapView.tsx
@@ -124,7 +124,20 @@ export default function MapView() {
     hasProcessed: false, // Changed from hasAttempted to hasProcessed
     timeoutId: null as NodeJS.Timeout | null,
     
-    // Simple check for navigation params
+    // Detect if the current URL change is intended for dashboard navigation, not map navigation
+    isDashboardNavigation(): boolean {
+      const url = new URL(window.location.href);
+      const pathname = url.pathname;
+      const hasTabParam = url.searchParams.has('tab');
+      const hasMapParams = url.searchParams.has('feature') || url.searchParams.has('boundary');
+      // Any navigation to dashboard or root should not be processed by the map controller
+      if (pathname === '/' || pathname.startsWith('/dashboard')) return true;
+      // If tab is present without map-specific params, it's not a map navigation
+      if (hasTabParam && !hasMapParams) return true;
+      return false;
+    },
+
+    // Simple check for navigation params (map-specific only)
     getNavigationParams(): { featureId: string | null; boundaryId: string | null } {
       const params = new URLSearchParams(window.location.search);
       return {
@@ -154,6 +167,12 @@ export default function MapView() {
     attemptNavigation(mapMethods: any, features: any[], boundaries: any[], toastCallback: Function) {
       // Skip if already processed
       if (this.hasProcessed) {
+        return;
+      }
+
+      // If this is a dashboard navigation or tab change, do not process as map navigation
+      if (this.isDashboardNavigation()) {
+        this.hasProcessed = true;
         return;
       }
       
@@ -225,6 +244,9 @@ export default function MapView() {
     setFailureTimeout(toastCallback: Function) {
       if (this.timeoutId || this.hasProcessed) return;
       
+      // Do not set a timeout for dashboard/tab navigations
+      if (this.isDashboardNavigation()) return;
+
       const { featureId, boundaryId } = this.getNavigationParams();
       if (!featureId && !boundaryId) return;
       
@@ -260,6 +282,13 @@ export default function MapView() {
   useEffect(() => {
     const controller = navigationController.current;
     const currentUrl = window.location.search;
+
+    // Ignore dashboard/tab-only navigations entirely
+    if (controller.isDashboardNavigation()) {
+      controller.hasProcessed = true;
+      lastProcessedUrl.current = currentUrl;
+      return;
+    }
     
     // Skip if we already processed this exact URL
     if (lastProcessedUrl.current === currentUrl && controller.hasProcessed) {


### PR DESCRIPTION
Prevent MapView's navigation controller from intercepting dashboard and tab-only URL navigations to fix infinite loop issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-60c24ace-6bc2-4c2a-908e-4ab13bb3cb8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60c24ace-6bc2-4c2a-908e-4ab13bb3cb8c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

