### PR TITLE
Restore map zoom functionality with url parameters

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -107,7 +107,12 @@ function BoundaryManagement() {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => setLocation(`/map?boundary=${boundary._id}`)}
+                      onClick={() => {
+                        try {
+                          sessionStorage.setItem('mapNavigation', JSON.stringify({ type: 'boundary', id: boundary._id.toString() }));
+                        } catch {}
+                        setLocation('/map');
+                      }}
                       className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
                     >
                       <MapPin className="h-4 w-4 mr-1" />
@@ -454,7 +459,12 @@ export default function Dashboard() {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => setLocation(`/map?boundary=${boundary._id}`)}
+                          onClick={() => {
+                            try {
+                              sessionStorage.setItem('mapNavigation', JSON.stringify({ type: 'boundary', id: boundary._id.toString() }));
+                            } catch {}
+                            setLocation('/map');
+                          }}
                           className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
                         >
                           <MapPin className="h-4 w-4 mr-1" />

--- a/client/src/pages/FeatureDetails.tsx
+++ b/client/src/pages/FeatureDetails.tsx
@@ -81,7 +81,10 @@ export default function FeatureDetails() {
   // Handle view on map
   const handleViewOnMap = () => {
     if (!feature?._id) return;
-    setLocation(`/map?feature=${feature._id}`);
+    try {
+      sessionStorage.setItem('mapNavigation', JSON.stringify({ type: 'feature', id: feature._id.toString() }));
+    } catch {}
+    setLocation('/map');
   };
 
   // Fetch team details if feature has a teamId

--- a/client/src/pages/FeatureList.tsx
+++ b/client/src/pages/FeatureList.tsx
@@ -225,7 +225,13 @@ export default function FeatureList() {
                     <Button 
                       variant="outline" 
                       size="sm"
-                      onClick={() => setLocation(`/map?${feature.feaType === 'Parcel' ? 'boundary' : 'feature'}=${feature._id}`)}
+                      onClick={() => {
+                        try {
+                          const type = feature.feaType === 'Parcel' ? 'boundary' : 'feature';
+                          sessionStorage.setItem('mapNavigation', JSON.stringify({ type, id: feature._id.toString() }));
+                        } catch {}
+                        setLocation('/map');
+                      }}
                       className="text-blue-600 hover:text-blue-700 hover:bg-blue-50"
                     >
                       <MapPin className="h-4 w-4 mr-1" />


### PR DESCRIPTION
Restore "View on Map" functionality to zoom to specific features/boundaries without relying on URL parameters.

This change updates "View on Map" buttons to store the target feature/boundary in `sessionStorage` before navigating to the map. `MapView` then reads this information to perform the zoom. Existing deep links using `?feature` or `?boundary` URL parameters are also supported by converting them to the new session-based mechanism once.

---
<a href="https://cursor.com/background-agent?bcId=bc-09a543db-21f0-4698-a7e4-d15482106fbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09a543db-21f0-4698-a7e4-d15482106fbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

