### PR TITLE
Integrate interactive London postcode map with Squarespace

### DIFF
--- a/london-map/README.md
+++ b/london-map/README.md
@@ -1,0 +1,33 @@
+## London Postcode Map (Mapbox GL JS)
+
+Static demo implementing an interactive postcode map for London with color-coded groups, lighter shade for missing info, clickable areas to pages, and a simple edit/export workflow.
+
+### Local run
+- Serve the folder with any static server, e.g.:
+  - Python: `python3 -m http.server 8080` from the `london-map` directory
+  - Then open `http://localhost:8080/`
+
+### Files
+- `index.html` – main map page
+- `styles.css` – layout and UI
+- `app.js` – Mapbox logic, editing, export
+- `data/postcodes.geojson` – simplified demo polygons
+- `config/postcodes.json` – metadata for each postcode
+- `pages/*.html` – placeholder pages for postcode codes
+
+### Map behavior
+- Color by group: SW, SE, W, E, N, NW, EC, WC
+- Lighter shade when `hasInfo: false`
+- Hover tooltip shows code and status
+- Click navigates to the `url` for the area
+- Edit mode: click a polygon to edit fields; Export JSON downloads the updated config
+
+### Squarespace integration
+1. Upload assets to Squarespace (Settings → Files) or host on a CDN. Upload:
+   - `styles.css`, `app.js`, `data/postcodes.geojson`, `config/postcodes.json`
+2. Create a page and add a Code Block. Paste the contents of `index.html` body only, and update asset URLs to the Squarespace-hosted URLs.
+3. Replace the `<script>window.MAPBOX_TOKEN=...</script>` with your Mapbox token if different.
+4. Update `config/postcodes.json` URLs to point to your Squarespace pages for each postcode, or keep the local `pages/*.html` for testing.
+
+### Replacing dummy polygons
+To use real London postcode boundaries, replace `data/postcodes.geojson` with an authoritative dataset (postcode areas/districts). Ensure each feature has properties: `code` (e.g. `SE1`) and `group` (e.g. `SE`). The color/shading logic will apply automatically.

--- a/london-map/app.js
+++ b/london-map/app.js
@@ -1,0 +1,263 @@
+/* global mapboxgl, MAPBOX_TOKEN */
+
+const DATA_URL = './data/postcodes.geojson';
+const CONFIG_URL = './config/postcodes.json';
+
+const groupColors = {
+  SW: '#e74c3c', // red
+  SE: '#27ae60', // green
+  W:  '#f39c12', // orange
+  E:  '#3498db', // blue
+  N:  '#9b59b6', // purple
+  NW: '#1abc9c', // teal
+  EC: '#34495e', // slate
+  WC: '#e67e22'  // carrot
+};
+
+let map;
+let postcodeGeojson;
+let postcodeConfig = {};
+let isEditMode = false;
+let hoveredFeatureId = null;
+
+init();
+
+async function init() {
+  try {
+    [postcodeGeojson, postcodeConfig] = await Promise.all([
+      fetch(DATA_URL).then(r => r.json()),
+      fetch(CONFIG_URL).then(r => r.json()).catch(() => ({}))
+    ]);
+  } catch (err) {
+    console.error('Failed to load data/config', err);
+    alert('Failed to load data or config');
+    return;
+  }
+
+  // Merge config into features and compute colors
+  postcodeGeojson.features = postcodeGeojson.features.map((feature, index) => {
+    const code = feature.properties.code;
+    const group = feature.properties.group;
+    const conf = postcodeConfig[code] || {};
+    const hasInfo = Boolean(conf.hasInfo);
+    const baseColor = groupColors[group] || '#95a5a6';
+    const fillColor = hasInfo ? baseColor : lightenHex(baseColor, 0.55);
+    const strokeColor = hasInfo ? darkenHex(baseColor, 0.15) : '#999999';
+
+    return {
+      ...feature,
+      id: index + 1,
+      properties: {
+        ...feature.properties,
+        hasInfo,
+        title: conf.title || code,
+        url: conf.url || `./pages/${code}.html`,
+        notes: conf.notes || '',
+        fill: fillColor,
+        stroke: strokeColor
+      }
+    };
+  });
+
+  mapboxgl.accessToken = MAPBOX_TOKEN;
+  map = new mapboxgl.Map({
+    container: 'map',
+    style: 'mapbox://styles/mapbox/light-v11',
+    center: [-0.1, 51.505],
+    zoom: 10.2,
+    attributionControl: true
+  });
+
+  map.addControl(new mapboxgl.NavigationControl({ showCompass: false }));
+  map.dragRotate.disable();
+  map.touchZoomRotate.disableRotation();
+
+  map.on('load', () => {
+    map.addSource('postcodes', {
+      type: 'geojson',
+      data: postcodeGeojson,
+      promoteId: 'id'
+    });
+
+    map.addLayer({
+      id: 'postcode-fills',
+      type: 'fill',
+      source: 'postcodes',
+      paint: {
+        'fill-color': ['get', 'fill'],
+        'fill-opacity': [
+          'case',
+          ['boolean', ['feature-state', 'hover'], false], 0.9,
+          0.7
+        ]
+      }
+    });
+
+    map.addLayer({
+      id: 'postcode-borders',
+      type: 'line',
+      source: 'postcodes',
+      paint: {
+        'line-color': ['get', 'stroke'],
+        'line-width': 1.5,
+        'line-opacity': 1
+      }
+    });
+
+    setupInteractions();
+    renderLegend();
+    bindUi();
+  });
+}
+
+function setupInteractions() {
+  const tooltip = document.getElementById('tooltip');
+
+  map.on('mousemove', 'postcode-fills', (e) => {
+    map.getCanvas().style.cursor = 'pointer';
+    const f = e.features && e.features[0];
+    if (!f) return;
+    if (hoveredFeatureId && hoveredFeatureId !== f.id) {
+      map.setFeatureState({ source: 'postcodes', id: hoveredFeatureId }, { hover: false });
+    }
+    hoveredFeatureId = f.id;
+    map.setFeatureState({ source: 'postcodes', id: hoveredFeatureId }, { hover: true });
+
+    const { code, title, group, hasInfo } = f.properties;
+    tooltip.innerHTML = `
+      <div><strong>${title}</strong></div>
+      <div>${code} (${group}) ${hasInfo ? '' : '— coming soon'}</div>
+    `;
+    const pt = e.point;
+    tooltip.style.left = pt.x + 'px';
+    tooltip.style.top = pt.y + 'px';
+    tooltip.hidden = false;
+  });
+
+  map.on('mouseleave', 'postcode-fills', () => {
+    map.getCanvas().style.cursor = '';
+    if (hoveredFeatureId) {
+      map.setFeatureState({ source: 'postcodes', id: hoveredFeatureId }, { hover: false });
+      hoveredFeatureId = null;
+    }
+    document.getElementById('tooltip').hidden = true;
+  });
+
+  map.on('click', 'postcode-fills', (e) => {
+    const f = e.features && e.features[0];
+    if (!f) return;
+    if (isEditMode) {
+      loadEditorFromFeature(f.properties);
+      return;
+    }
+    const url = f.properties.url;
+    if (url) {
+      window.location.href = url;
+    }
+  });
+}
+
+function renderLegend() {
+  const legend = document.getElementById('legendItems');
+  legend.innerHTML = '';
+  Object.entries(groupColors).forEach(([group, color]) => {
+    const item = document.createElement('div');
+    item.className = 'legend-item';
+    const swatch = document.createElement('span');
+    swatch.className = 'legend-swatch';
+    swatch.style.background = color;
+    const label = document.createElement('span');
+    label.textContent = group;
+    item.appendChild(swatch);
+    item.appendChild(label);
+    legend.appendChild(item);
+  });
+}
+
+function bindUi() {
+  const toggleBtn = document.getElementById('toggleEditBtn');
+  const editor = document.getElementById('editor');
+  const resetBtn = document.getElementById('resetBtn');
+  const exportBtn = document.getElementById('exportConfigBtn');
+
+  toggleBtn.addEventListener('click', () => {
+    isEditMode = !isEditMode;
+    toggleBtn.textContent = isEditMode ? 'Exit edit' : 'Edit mode';
+    editor.hidden = !isEditMode;
+    document.getElementById('sidebar').scrollTop = 0;
+  });
+
+  document.getElementById('editForm').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const code = document.getElementById('fieldCode').value;
+    const title = document.getElementById('fieldTitle').value.trim() || code;
+    const url = document.getElementById('fieldUrl').value.trim() || `./pages/${code}.html`;
+    const hasInfo = document.getElementById('fieldHasInfo').checked;
+    const notes = document.getElementById('fieldNotes').value.trim();
+
+    postcodeConfig[code] = { title, url, hasInfo, notes };
+
+    // Update feature properties and map paint
+    const f = postcodeGeojson.features.find(ft => ft.properties.code === code);
+    if (f) {
+      f.properties.title = title;
+      f.properties.url = url;
+      f.properties.hasInfo = hasInfo;
+      f.properties.notes = notes;
+      const baseColor = groupColors[f.properties.group] || '#95a5a6';
+      f.properties.fill = hasInfo ? baseColor : lightenHex(baseColor, 0.55);
+      f.properties.stroke = hasInfo ? darkenHex(baseColor, 0.15) : '#999999';
+      map.getSource('postcodes').setData(postcodeGeojson);
+    }
+  });
+
+  resetBtn.addEventListener('click', () => {
+    document.getElementById('editForm').reset();
+  });
+
+  exportBtn.addEventListener('click', () => {
+    const blob = new Blob([JSON.stringify(postcodeConfig, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'postcodes.config.json';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+  });
+}
+
+function loadEditorFromFeature(props) {
+  document.getElementById('fieldCode').value = props.code || '';
+  document.getElementById('fieldTitle').value = props.title || '';
+  document.getElementById('fieldUrl').value = props.url || '';
+  document.getElementById('fieldHasInfo').checked = Boolean(props.hasInfo);
+  document.getElementById('fieldNotes').value = props.notes || '';
+}
+
+// Color helpers
+function hexToRgb(hex) {
+  const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return m ? { r: parseInt(m[1], 16), g: parseInt(m[2], 16), b: parseInt(m[3], 16) } : { r: 0, g: 0, b: 0 };
+}
+function rgbToHex(r, g, b) {
+  return '#' + [r, g, b].map(v => {
+    const s = Math.max(0, Math.min(255, Math.round(v))).toString(16).padStart(2, '0');
+    return s;
+  }).join('');
+}
+function lightenHex(hex, amount = 0.3) {
+  const { r, g, b } = hexToRgb(hex);
+  const newR = r + (255 - r) * amount;
+  const newG = g + (255 - g) * amount;
+  const newB = b + (255 - b) * amount;
+  return rgbToHex(newR, newG, newB);
+}
+function darkenHex(hex, amount = 0.15) {
+  const { r, g, b } = hexToRgb(hex);
+  const newR = r * (1 - amount);
+  const newG = g * (1 - amount);
+  const newB = b * (1 - amount);
+  return rgbToHex(newR, newG, newB);
+}

--- a/london-map/config/postcodes.json
+++ b/london-map/config/postcodes.json
@@ -1,0 +1,10 @@
+{
+  "SW1": { "title": "SW1 — Westminster & Belgravia", "hasInfo": true,  "url": "./pages/SW1.html", "notes": "Example area with info" },
+  "SE1": { "title": "SE1 — South Bank & Bermondsey", "hasInfo": false, "url": "./pages/SE1.html", "notes": "Info coming soon" },
+  "W1":  { "title": "W1 — Marylebone & Mayfair", "hasInfo": true,  "url": "./pages/W1.html" },
+  "E1":  { "title": "E1 — Whitechapel & Shoreditch", "hasInfo": true,  "url": "./pages/E1.html" },
+  "N1":  { "title": "N1 — Islington", "hasInfo": false, "url": "./pages/N1.html" },
+  "NW1": { "title": "NW1 — Camden Town", "hasInfo": false, "url": "./pages/NW1.html" },
+  "EC1": { "title": "EC1 — Clerkenwell", "hasInfo": true,  "url": "./pages/EC1.html" },
+  "WC1": { "title": "WC1 — Bloomsbury", "hasInfo": false, "url": "./pages/WC1.html" }
+}

--- a/london-map/data/postcodes.geojson
+++ b/london-map/data/postcodes.geojson
@@ -1,0 +1,125 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": 1,
+      "properties": { "code": "SW1", "group": "SW", "name": "South West 1" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-0.18, 51.46],
+          [-0.07, 51.46],
+          [-0.07, 51.50],
+          [-0.18, 51.50],
+          [-0.18, 51.46]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 2,
+      "properties": { "code": "SE1", "group": "SE", "name": "South East 1" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-0.10, 51.48],
+          [0.05, 51.48],
+          [0.05, 51.54],
+          [-0.10, 51.54],
+          [-0.10, 51.48]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 3,
+      "properties": { "code": "W1", "group": "W", "name": "West 1" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-0.22, 51.50],
+          [-0.12, 51.50],
+          [-0.12, 51.54],
+          [-0.22, 51.54],
+          [-0.22, 51.50]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 4,
+      "properties": { "code": "E1", "group": "E", "name": "East 1" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-0.07, 51.52],
+          [0.08, 51.52],
+          [0.08, 51.57],
+          [-0.07, 51.57],
+          [-0.07, 51.52]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 5,
+      "properties": { "code": "N1", "group": "N", "name": "North 1" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-0.20, 51.55],
+          [0.02, 51.55],
+          [0.02, 51.60],
+          [-0.20, 51.60],
+          [-0.20, 51.55]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 6,
+      "properties": { "code": "NW1", "group": "NW", "name": "North West 1" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-0.25, 51.54],
+          [-0.12, 51.54],
+          [-0.12, 51.60],
+          [-0.25, 51.60],
+          [-0.25, 51.54]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 7,
+      "properties": { "code": "EC1", "group": "EC", "name": "East Central 1" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-0.11, 51.51],
+          [-0.08, 51.51],
+          [-0.08, 51.53],
+          [-0.11, 51.53],
+          [-0.11, 51.51]
+        ]]
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 8,
+      "properties": { "code": "WC1", "group": "WC", "name": "West Central 1" },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [[
+          [-0.14, 51.51],
+          [-0.11, 51.51],
+          [-0.11, 51.53],
+          [-0.14, 51.53],
+          [-0.14, 51.51]
+        ]]
+      }
+    }
+  ]
+}

--- a/london-map/index.html
+++ b/london-map/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>London Postcode Map</title>
+  <link href="https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.css" rel="stylesheet" />
+  <link href="./styles.css" rel="stylesheet" />
+</head>
+<body>
+  <header class="app-header">
+    <div class="branding">
+      <h1>London Postcode Map</h1>
+      <p>Interactive postcode areas with clickable pages</p>
+    </div>
+    <div class="header-actions">
+      <button id="toggleEditBtn" class="btn">Edit mode</button>
+      <button id="exportConfigBtn" class="btn secondary">Export JSON</button>
+    </div>
+  </header>
+
+  <main class="app-main">
+    <aside class="sidebar" id="sidebar">
+      <section class="legend" id="legend">
+        <h3>Legend</h3>
+        <div class="legend-items" id="legendItems"></div>
+        <div class="legend-note">
+          <span class="legend-swatch swatch-missing"></span>
+          <span>Shaded = Missing info</span>
+        </div>
+      </section>
+
+      <section class="editor" id="editor" hidden>
+        <h3>Edit Postcode</h3>
+        <form id="editForm">
+          <div class="form-row">
+            <label>Code</label>
+            <input id="fieldCode" type="text" readonly />
+          </div>
+          <div class="form-row">
+            <label>Title</label>
+            <input id="fieldTitle" type="text" placeholder="Display title" />
+          </div>
+          <div class="form-row">
+            <label>URL</label>
+            <input id="fieldUrl" type="url" placeholder="/pages/SW1.html or full URL" />
+          </div>
+          <div class="form-row checkbox">
+            <label>
+              <input id="fieldHasInfo" type="checkbox" /> Has information page
+            </label>
+          </div>
+          <div class="form-row">
+            <label>Notes</label>
+            <textarea id="fieldNotes" rows="3" placeholder="Optional notes"></textarea>
+          </div>
+          <div class="form-actions">
+            <button type="submit" class="btn">Save</button>
+            <button type="button" id="resetBtn" class="btn secondary">Reset</button>
+          </div>
+        </form>
+        <p class="help-text">Changes are kept in-memory. Use "Export JSON" to download the updated config to upload to your site.</p>
+      </section>
+    </aside>
+
+    <section class="map-wrap">
+      <div id="map"></div>
+      <div id="tooltip" class="tooltip" hidden></div>
+    </section>
+  </main>
+
+  <script src="https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.js"></script>
+  <script>
+    window.MAPBOX_TOKEN = 'pk.eyJ1Ijoia2FsaWJlMjAiLCJhIjoiY2x5bXZtZDkxMDF6NjJqc2RwcDYwdzBsOCJ9.sM2piYvs-KRuVtcvNflmvQ';
+  </script>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/london-map/pages/E1.html
+++ b/london-map/pages/E1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>E1 — Whitechapel & Shoreditch</title><link rel="stylesheet" href="../styles.css"></head>
+<body>
+  <main style="max-width: 760px; margin: 40px auto; padding: 0 16px;">
+    <h1>E1 — Whitechapel & Shoreditch</h1>
+    <p>This is a placeholder content page for E1. Replace with buyer-supplied information.</p>
+    <p><a class="btn" href="../index.html">Back to map</a></p>
+  </main>
+</body></html>

--- a/london-map/pages/EC1.html
+++ b/london-map/pages/EC1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>EC1 — Clerkenwell</title><link rel="stylesheet" href="../styles.css"></head>
+<body>
+  <main style="max-width: 760px; margin: 40px auto; padding: 0 16px;">
+    <h1>EC1 — Clerkenwell</h1>
+    <p>This is a placeholder content page for EC1. Replace with buyer-supplied information.</p>
+    <p><a class="btn" href="../index.html">Back to map</a></p>
+  </main>
+</body></html>

--- a/london-map/pages/N1.html
+++ b/london-map/pages/N1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>N1 — Islington</title><link rel="stylesheet" href="../styles.css"></head>
+<body>
+  <main style="max-width: 760px; margin: 40px auto; padding: 0 16px;">
+    <h1>N1 — Islington</h1>
+    <p>Information for N1 is coming soon. This page is a placeholder.</p>
+    <p><a class="btn" href="../index.html">Back to map</a></p>
+  </main>
+</body></html>

--- a/london-map/pages/NW1.html
+++ b/london-map/pages/NW1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>NW1 — Camden Town</title><link rel="stylesheet" href="../styles.css"></head>
+<body>
+  <main style="max-width: 760px; margin: 40px auto; padding: 0 16px;">
+    <h1>NW1 — Camden Town</h1>
+    <p>Information for NW1 is coming soon. This page is a placeholder.</p>
+    <p><a class="btn" href="../index.html">Back to map</a></p>
+  </main>
+</body></html>

--- a/london-map/pages/SE1.html
+++ b/london-map/pages/SE1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>SE1 — South Bank & Bermondsey</title><link rel="stylesheet" href="../styles.css"></head>
+<body>
+  <main style="max-width: 760px; margin: 40px auto; padding: 0 16px;">
+    <h1>SE1 — South Bank & Bermondsey</h1>
+    <p>Information for SE1 is coming soon. This page is a placeholder.</p>
+    <p><a class="btn" href="../index.html">Back to map</a></p>
+  </main>
+</body></html>

--- a/london-map/pages/SW1.html
+++ b/london-map/pages/SW1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>SW1 — Westminster & Belgravia</title><link rel="stylesheet" href="../styles.css"></head>
+<body>
+  <main style="max-width: 760px; margin: 40px auto; padding: 0 16px;">
+    <h1>SW1 — Westminster & Belgravia</h1>
+    <p>This is a placeholder content page for SW1. Replace with buyer-supplied information.</p>
+    <p><a class="btn" href="../index.html">Back to map</a></p>
+  </main>
+</body></html>

--- a/london-map/pages/W1.html
+++ b/london-map/pages/W1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>W1 — Marylebone & Mayfair</title><link rel="stylesheet" href="../styles.css"></head>
+<body>
+  <main style="max-width: 760px; margin: 40px auto; padding: 0 16px;">
+    <h1>W1 — Marylebone & Mayfair</h1>
+    <p>This is a placeholder content page for W1. Replace with buyer-supplied information.</p>
+    <p><a class="btn" href="../index.html">Back to map</a></p>
+  </main>
+</body></html>

--- a/london-map/pages/WC1.html
+++ b/london-map/pages/WC1.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/><title>WC1 — Bloomsbury</title><link rel="stylesheet" href="../styles.css"></head>
+<body>
+  <main style="max-width: 760px; margin: 40px auto; padding: 0 16px;">
+    <h1>WC1 — Bloomsbury</h1>
+    <p>Information for WC1 is coming soon. This page is a placeholder.</p>
+    <p><a class="btn" href="../index.html">Back to map</a></p>
+  </main>
+</body></html>

--- a/london-map/styles.css
+++ b/london-map/styles.css
@@ -1,0 +1,38 @@
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; color: #222; }
+
+.app-header { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px 16px; border-bottom: 1px solid #eee; background: #fff; position: sticky; top: 0; z-index: 10; }
+.app-header .branding h1 { margin: 0 0 4px 0; font-size: 20px; }
+.app-header .branding p { margin: 0; color: #666; font-size: 13px; }
+
+.btn { appearance: none; border: 1px solid #ccc; background: #111; color: #fff; padding: 8px 12px; border-radius: 8px; cursor: pointer; font-weight: 600; font-size: 14px; }
+.btn:hover { opacity: 0.9; }
+.btn.secondary { background: #fff; color: #111; border-color: #ddd; }
+
+.app-main { display: grid; grid-template-columns: 320px 1fr; height: calc(100% - 65px); }
+.sidebar { border-right: 1px solid #eee; padding: 16px; overflow: auto; }
+.map-wrap { position: relative; }
+#map { position: absolute; inset: 0; }
+
+.legend h3, .editor h3 { margin-top: 0; }
+.legend-items { display: grid; grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 8px; }
+.legend-item { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+.legend-swatch { width: 16px; height: 16px; border-radius: 4px; border: 1px solid #0001; display: inline-block; }
+.legend-note { display: flex; align-items: center; gap: 8px; margin-top: 8px; color: #666; font-size: 12px; }
+.legend-swatch.swatch-missing { background: repeating-linear-gradient(45deg, #00000010, #00000010 6px, #00000005 6px, #00000005 12px); border: 1px dashed #bbb; }
+
+.editor .form-row { margin-bottom: 10px; }
+.editor label { display: block; font-weight: 600; margin-bottom: 6px; font-size: 13px; }
+.editor input[type="text"], .editor input[type="url"], .editor textarea { width: 100%; padding: 8px; border-radius: 8px; border: 1px solid #ddd; font-size: 14px; }
+.editor .checkbox label { display: flex; align-items: center; gap: 8px; font-weight: 500; }
+.editor .form-actions { display: flex; gap: 8px; }
+.help-text { color: #666; font-size: 12px; }
+
+.tooltip { position: absolute; pointer-events: none; background: #111; color: #fff; font-size: 12px; padding: 6px 8px; border-radius: 6px; transform: translate(-50%, calc(-100% - 8px)); white-space: nowrap; box-shadow: 0 4px 16px rgba(0,0,0,0.15); }
+.tooltip::after { content: ""; position: absolute; bottom: -5px; left: 50%; transform: translateX(-50%); width: 8px; height: 8px; background: #111; rotate: 45deg; }
+
+@media (max-width: 900px) {
+  .app-main { grid-template-columns: 1fr; }
+  .sidebar { order: 2; height: 42vh; }
+  .map-wrap { order: 1; height: 58vh; }
+}


### PR DESCRIPTION
Implement an interactive London postcode map with color-coded areas, information pages, and an edit mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-266926d1-199e-4e55-a8d1-8f9e4b2870f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-266926d1-199e-4e55-a8d1-8f9e4b2870f1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

