### PR TITLE
Fix boundaries page authentication error

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -9,7 +9,7 @@ import { useToast } from '@/hooks/use-toast';
 import { queryClient } from '@/lib/queryClient';
 import { getAllBoundaries, deleteBoundary } from '@/lib/api';
 import FeatureIcon, { FeatureType } from '@/components/FeatureIcon';
-import { Trash2, MapPin, Users } from 'lucide-react';
+import { Trash2, MapPin, Users, Calendar } from 'lucide-react';
 
 // Boundary Management Component
 function BoundaryManagement() {


### PR DESCRIPTION
Import missing Calendar icon to fix crash on Boundaries tab.

The Boundaries tab was crashing with an error boundary message because the `<Calendar />` component was used without being imported.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b103fdd-64c9-47c5-9256-dc589ee4a639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b103fdd-64c9-47c5-9256-dc589ee4a639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

