### PR TITLE
Fix mapview image loading and layer issues

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -29,6 +29,19 @@ export default function AppHeader() {
   };
 
   const toggleSidebar = () => {
+    // Prefer new sidebar system if present
+    const sidebarWrapper = document.querySelector('[data-sidebar="sidebar"]') as HTMLElement | null;
+    if (sidebarWrapper) {
+      // Toggle using data-state on parent wrapper if available
+      const provider = sidebarWrapper.closest('.group/sidebar-wrapper') as HTMLElement | null;
+      if (provider) {
+        const isCollapsed = provider.getAttribute('data-collapsible') === 'icon';
+        provider.setAttribute('data-collapsible', isCollapsed ? 'offcanvas' : 'icon');
+        return;
+      }
+    }
+
+    // Fallback to legacy side-nav id
     const sidebar = document.getElementById("side-nav");
     if (sidebar) {
       // Toggle the sidebar visibility

--- a/client/src/components/SideNavigation.tsx
+++ b/client/src/components/SideNavigation.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function SideNavigation() {
   return (
-    <aside className="w-56 shrink-0 border-r bg-white hidden md:flex md:flex-col">
+    <aside id="side-nav" className="w-56 shrink-0 border-r bg-white hidden md:flex md:flex-col">
       <nav className="p-4 space-y-2 text-sm text-gray-700">
         <a href="/dashboard" className="block px-2 py-1 rounded hover:bg-gray-100">Dashboard</a>
         <a href="/map" className="block px-2 py-1 rounded hover:bg-gray-100">Map View</a>

--- a/client/src/lib/OpenLayersMap.tsx
+++ b/client/src/lib/OpenLayersMap.tsx
@@ -569,7 +569,9 @@ const OpenLayersMap = ({
             })
           });
         }
-      }
+      },
+      // Ensure features render above shapefiles
+      zIndex: 500
     });
 
     teamsLayerRef.current = new VectorLayer({
@@ -592,7 +594,9 @@ const OpenLayersMap = ({
             font: 'bold 14px Arial'
           })
         });
-      }
+      },
+      // Keep teams above shapefiles but below user-location/accuracy
+      zIndex: 520
     });
 
     boundariesLayerRef.current = new VectorLayer({
@@ -628,7 +632,9 @@ const OpenLayersMap = ({
             lineDash: [8, 8] // More prominent dashed line for better visibility
           })
         });
-      }
+      },
+      // Ensure boundaries render above shapefiles and features if needed
+      zIndex: 550
     });
 
     tasksLayerRef.current = new VectorLayer({
@@ -652,7 +658,9 @@ const OpenLayersMap = ({
             font: 'bold 12px Arial'
           })
         });
-      }
+      },
+      // Ensure tasks are above shapefiles
+      zIndex: 530
     });
 
     selectedLocationLayerRef.current = new VectorLayer({
@@ -747,7 +755,8 @@ const OpenLayersMap = ({
             });
         }
       },
-      zIndex: 600 // Ensure it's above other layers but below selections
+      // Always keep shapefiles beneath features and boundaries
+      zIndex: 100
     });
 
     // Create location layers for user position with identifiable names

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -241,8 +241,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
     fs.mkdirSync(path.join(process.cwd(), "uploads"), { recursive: true });
   }
 
-  // Serve static uploads
-  app.use("/uploads", express.static(path.join(process.cwd(), "uploads")));
+  // Serve static uploads with no-cache to ensure fresh image reloads
+  app.use(
+    "/uploads",
+    express.static(path.join(process.cwd(), "uploads"), {
+      etag: true,
+      lastModified: true,
+      setHeaders: (res) => {
+        // Prevent aggressive caching by proxies/browsers during frequent updates
+        res.setHeader("Cache-Control", "no-cache, no-store, max-age=0, must-revalidate");
+        res.setHeader("Pragma", "no-cache");
+        res.setHeader("Expires", "0");
+      },
+    }),
+  );
 
   // Hybrid authentication middleware: tries session first, then JWT
   const isAuthenticated = async (req: Request, res: Response, next: any) => {


### PR DESCRIPTION
Fixes map layer ordering, image reloads, and sidebar behavior.

Map features and boundaries were unselectable when shapefiles were present due to incorrect layer ordering. Edited images failed to reload because of browser caching. The sidebar toggle was broken due to a missing ID and changes in the sidebar's underlying implementation.

---
<a href="https://cursor.com/background-agent?bcId=bc-07653b3b-f3d2-466a-a88c-5345a314a5f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-07653b3b-f3d2-466a-a88c-5345a314a5f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

