### PR TITLE
Fix shapefile on off functionality

### DIFF
--- a/client/src/pages/MapView.tsx
+++ b/client/src/pages/MapView.tsx
@@ -565,7 +565,17 @@ export default function MapView() {
           visibleSavedShapefiles.map(processSavedShapefileWithShpJS)
         );
         
-        const combined = [...localShapefiles, ...processedSavedShapefiles];
+        // Deduplicate by _id (prefer saved entries) and ensure toggling hides any local duplicate
+        const savedIds = new Set(
+          (savedShapefiles as any[]).map((s) => (s?._id ?? (s as any)?.id ?? '').toString())
+        );
+        const filteredLocal = localShapefiles.filter((local: any) => {
+          const localId = (local?._id ?? local?.id ?? '').toString();
+          // Exclude local if there is any saved entry with the same id
+          return localId.length === 0 || !savedIds.has(localId);
+        });
+        
+        const combined = [...filteredLocal, ...processedSavedShapefiles];
         setAllShapefiles(combined);
       } catch (error) {
         console.error('Error processing shapefiles:', error);


### PR DESCRIPTION
Fix shapefile visibility toggle by ensuring saved shapefile state correctly controls display, even if a local duplicate exists.

---
<a href="https://cursor.com/background-agent?bcId=bc-22f02b8b-0b88-42f2-b40d-ba8700b33935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-22f02b8b-0b88-42f2-b40d-ba8700b33935">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

