### PR TITLE
Fix shapefile visibility and button state

### DIFF
--- a/client/src/pages/MapView.tsx
+++ b/client/src/pages/MapView.tsx
@@ -558,7 +558,7 @@ export default function MapView() {
       processingRef.current = true;
       
       try {
-        const visibleSavedShapefiles = savedShapefiles.filter((shapefile: any) => shapefile.isVisible);
+        const visibleSavedShapefiles = savedShapefiles.filter((shapefile: any) => shapefile.isVisible !== false);
         
         // Process saved shapefiles asynchronously - KEEP ALL ORIGINAL LOGIC
         const processedSavedShapefiles = await Promise.all(


### PR DESCRIPTION
Fix shapefile visibility toggle button getting stuck disabled and enhance 502 error handling for visibility updates.

The shapefile visibility toggle button would disable all buttons during an API request and sometimes fail to re-enable on 502 errors. This PR introduces per-button disabling, ensures re-enabling on all outcomes, provides specific 502 UI feedback, corrects initial visibility logic to treat undefined as visible, and hardens the server API with ID validation and explicit 502 responses for upstream issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-30425f21-e121-4fd5-afc4-ad90b959fd2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-30425f21-e121-4fd5-afc4-ad90b959fd2e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

