### PR TITLE
Fix feature tower view details button

### DIFF
--- a/client/src/pages/FeatureDetails.tsx
+++ b/client/src/pages/FeatureDetails.tsx
@@ -1,10 +1,94 @@
-import React from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { useParams, useLocation } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { FeatureDetailsModal } from "@/components/FeatureDetailsModal";
+import { getFeature } from "@/lib/api";
+import type { IFeature } from "@shared/schema";
 
 export default function FeatureDetails() {
+  const params = useParams();
+  const [, setLocation] = useLocation();
+  const featureId = useMemo(() => params?.featureId as string | undefined, [params]);
+  const [isModalOpen, setIsModalOpen] = useState(true);
+
+  const { data: feature, isLoading, isError } = useQuery<IFeature>({
+    queryKey: ["/api/features", featureId],
+    queryFn: async () => {
+      if (!featureId) throw new Error("Missing feature id");
+      return await getFeature(featureId);
+    },
+    enabled: !!featureId,
+    staleTime: 0,
+  });
+
+  useEffect(() => {
+    // If the modal closes, go back to the list
+    if (!isModalOpen && params?.featureType) {
+      setLocation(`/features/${params.featureType}`);
+    }
+  }, [isModalOpen, params, setLocation]);
+
+  if (!featureId) {
+    return (
+      <div className="p-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Feature not found</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-gray-600">No feature id was provided.</p>
+              <Button variant="outline" onClick={() => setLocation("/features/all")}>Back</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="p-4">
+        <Card>
+          <CardContent className="p-6">
+            <div className="animate-pulse space-y-3">
+              <div className="h-6 bg-gray-200 rounded w-1/3"></div>
+              <div className="h-4 bg-gray-200 rounded w-2/3"></div>
+              <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (isError || !feature) {
+    return (
+      <div className="p-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Unable to load feature</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-gray-600">Please try again.</p>
+              <Button variant="outline" onClick={() => setLocation(`/features/${params?.featureType || "all"}`)}>Back</Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
-    <div className="p-4">
-      <h1 className="text-lg font-semibold">Feature Details</h1>
-      <p className="text-sm text-gray-600">Select a feature from the list to view details.</p>
+    <div className="p-0">
+      <FeatureDetailsModal
+        open={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        feature={feature}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Implement the `FeatureDetails` page to fetch and display feature details, resolving the issue where clicking "View Details" showed an empty page.

---
<a href="https://cursor.com/background-agent?bcId=bc-9187b9da-c4ba-4938-a4b3-475894c54bc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9187b9da-c4ba-4938-a4b3-475894c54bc4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

