### PR TITLE
Allow supervisor to delete features and teams

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -379,6 +379,11 @@ export async function getTeamMembers(teamId: number) {
   return await res.json();
 }
 
+export async function deleteTeam(teamId: string) {
+  const res = await apiRequest('DELETE', `/api/teams/${teamId}`);
+  return await res.json();
+}
+
 export async function assignUserToTeam(userId: number, teamId: number) {
   const res = await apiRequest('POST', `/api/users/${userId}/assign-team`, { teamId });
   return await res.json();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1505,6 +1505,32 @@ export async function registerRoutes(app: Express): Promise<Server> {
     },
   );
 
+  // Delete team (supervisor only)
+  app.delete(
+    "/api/teams/:id",
+    isSupervisor,
+    validateObjectId("id"),
+    async (req, res) => {
+      try {
+        const teamId = req.params.id;
+        const team = await storage.getTeam(teamId);
+        if (!team) {
+          return res.status(404).json({ message: "Team not found" });
+        }
+
+        const deleted = await storage.deleteTeam(teamId);
+        if (!deleted) {
+          return res.status(500).json({ message: "Failed to delete team" });
+        }
+
+        res.json({ message: "Team deleted successfully" });
+      } catch (error) {
+        console.error("Delete team error:", error);
+        res.status(500).json({ message: "Failed to delete team" });
+      }
+    },
+  );
+
   app.get(
     "/api/teams/:id/users",
     isAuthenticated,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -19,6 +19,7 @@ export interface IStorage {
   getTeam(id: string): Promise<ITeam | undefined>;
   getTeamByName(name: string): Promise<ITeam | undefined>;
   updateTeamStatus(id: string, status: string, approvedBy?: string): Promise<ITeam>;
+  deleteTeam(id: string): Promise<boolean>;
   getAllTeams(): Promise<ITeam[]>;
   getUsersByTeam(teamId: string): Promise<IUser[]>;
   assignUserToTeam(userId: string, teamId: string): Promise<IUser>;
@@ -133,6 +134,10 @@ export class MemStorage implements IStorage {
   }
 
   async assignUserToTeam(userId: string, teamId: string): Promise<IUser> {
+    throw new Error('MemStorage is a stub - use MongoStorage instead');
+  }
+
+  async deleteTeam(id: string): Promise<boolean> {
     throw new Error('MemStorage is a stub - use MongoStorage instead');
   }
 


### PR DESCRIPTION
Implement team deletion for supervisors, including cascading cleanup, and confirm supervisor access to feature deletion.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dd04fc2-ee24-4920-ac00-7da715732f2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9dd04fc2-ee24-4920-ac00-7da715732f2c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

