### PR TITLE
Fix dashboard dialog description error

### DIFF
--- a/client/src/components/CreateTaskModal.tsx
+++ b/client/src/components/CreateTaskModal.tsx
@@ -12,6 +12,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
 import {


### PR DESCRIPTION
Add missing `DialogDescription` import to `CreateTaskModal.tsx` to resolve a `ReferenceError` when creating inspection tasks.

The error "DialogDescription is not defined" occurred because the `DialogDescription` component was used in the `CreateTaskModal` JSX but was not explicitly imported from `@/components/ui/dialog`. This PR adds the necessary import to fix the runtime error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f66fe9da-64cd-4bc8-8d20-b91d22144600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f66fe9da-64cd-4bc8-8d20-b91d22144600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

