### PR TITLE
Fix drawing tool initialization bug

### DIFF
--- a/client/src/components/FeatureSelectionDialog.tsx
+++ b/client/src/components/FeatureSelectionDialog.tsx
@@ -111,8 +111,12 @@ const FeatureSelectionDialog = ({
       description: instructions[feature.drawingType],
     });
 
-    onFeatureSelect(feature.id, feature.drawingType);
+    // Close the dialog first so its overlay doesn't swallow the first map click
     onOpenChange(false);
+    // Defer enabling drawing until after the dialog unmounts
+    setTimeout(() => {
+      onFeatureSelect(feature.id, feature.drawingType);
+    }, 0);
   };
 
   return (


### PR DESCRIPTION
Defer drawing tool activation to prevent the feature selection dialog's overlay from swallowing the first map click.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8a658ac-be64-4ba1-8725-8e4d2f6e7e22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8a658ac-be64-4ba1-8725-8e4d2f6e7e22">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

