### PR TITLE
Fix dashboard tower sort and edit bug

### DIFF
--- a/client/src/pages/FeatureDetails.tsx
+++ b/client/src/pages/FeatureDetails.tsx
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { FeatureDetailsModal } from "@/components/FeatureDetailsModal";
+import { EditFeatureModal } from "@/components/EditFeatureModal";
 import { getFeature } from "@/lib/api";
 import type { IFeature } from "@shared/schema";
 
@@ -12,6 +13,7 @@ export default function FeatureDetails() {
   const [, setLocation] = useLocation();
   const featureId = useMemo(() => params?.featureId as string | undefined, [params]);
   const [isModalOpen, setIsModalOpen] = useState(true);
+  const [isEditOpen, setIsEditOpen] = useState(false);
 
   const { data: feature, isLoading, isError } = useQuery<IFeature>({
     queryKey: ["/api/features", featureId],
@@ -87,6 +89,19 @@ export default function FeatureDetails() {
       <FeatureDetailsModal
         open={isModalOpen}
         onClose={() => setIsModalOpen(false)}
+        feature={feature}
+        onEdit={() => {
+          setIsModalOpen(false);
+          setIsEditOpen(true);
+        }}
+      />
+      <EditFeatureModal
+        open={isEditOpen}
+        onClose={() => {
+          setIsEditOpen(false);
+          // After editing, return to the details modal for consistency
+          setIsModalOpen(true);
+        }}
         feature={feature}
       />
     </div>


### PR DESCRIPTION
Wire the Edit button in `FeatureDetailsModal` to open `EditFeatureModal`, fixing the issue where editing features did nothing after sorting.

---
<a href="https://cursor.com/background-agent?bcId=bc-04e51bee-1331-48b9-a835-e25a2c261f74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04e51bee-1331-48b9-a835-e25a2c261f74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

