### PR TITLE
Manage field team members

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -389,8 +389,13 @@ export async function deleteTeam(teamId: string) {
   return await res.json();
 }
 
-export async function assignUserToTeam(userId: number, teamId: number) {
+export async function assignUserToTeam(userId: string, teamId: string) {
   const res = await apiRequest('POST', `/api/users/${userId}/assign-team`, { teamId });
+  return await res.json();
+}
+
+export async function unassignUserFromTeam(userId: string) {
+  const res = await apiRequest('POST', `/api/users/${userId}/unassign-team`);
   return await res.json();
 }
 

--- a/server/dbStorage.ts
+++ b/server/dbStorage.ts
@@ -537,6 +537,21 @@ export class MongoStorage implements IStorage {
     return user;
   }
 
+  async unassignUserFromTeam(userId: string): Promise<IUser> {
+    if (!isValidObjectId(userId)) {
+      throw new Error("Invalid user ID");
+    }
+
+    const user = await User.findByIdAndUpdate(
+      userId,
+      { $unset: { teamId: "" } },
+      { new: true }
+    ).exec();
+
+    if (!user) throw new Error("User not found");
+    return user as any;
+  }
+
   async deleteTeam(id: string): Promise<boolean> {
     if (!isValidObjectId(id)) return false;
 

--- a/server/mongoStorage.ts
+++ b/server/mongoStorage.ts
@@ -223,6 +223,22 @@ export class MongoStorage implements IStorage {
     }
   }
 
+  async unassignUserFromTeam(userId: string): Promise<IUser> {
+    try {
+      const user = await User.findById(userId);
+      if (!user) {
+        throw new Error(`User with ID ${userId} not found`);
+      }
+
+      user.teamId = undefined as any;
+      await user.save();
+      return user;
+    } catch (error) {
+      console.error("Error unassigning user from team:", error);
+      throw error;
+    }
+  }
+
   // Task operations
   async createTask(taskData: InsertTask): Promise<ITask> {
     try {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1668,6 +1668,23 @@ export async function registerRoutes(app: Express): Promise<Server> {
     },
   );
 
+  app.post(
+    "/api/users/:id/unassign-team",
+    isSupervisor,
+    validateObjectId("id"),
+    async (req, res) => {
+      try {
+        const userId = req.params.id;
+        const updatedUser = await storage.unassignUserFromTeam(userId);
+        const { password, ...userResponse } = updatedUser as any;
+        res.json(userResponse);
+      } catch (error) {
+        console.error("Unassign user from team error:", error);
+        res.status(500).json({ message: "Failed to unassign user from team" });
+      }
+    },
+  );
+
   // Task routes
   app.post("/api/tasks", isAuthenticated, async (req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -23,6 +23,7 @@ export interface IStorage {
   getAllTeams(): Promise<ITeam[]>;
   getUsersByTeam(teamId: string): Promise<IUser[]>;
   assignUserToTeam(userId: string, teamId: string): Promise<IUser>;
+  unassignUserFromTeam(userId: string): Promise<IUser>;
   
   // Task operations
   createTask(taskData: InsertTask): Promise<ITask>;
@@ -134,6 +135,10 @@ export class MemStorage implements IStorage {
   }
 
   async assignUserToTeam(userId: string, teamId: string): Promise<IUser> {
+    throw new Error('MemStorage is a stub - use MongoStorage instead');
+  }
+
+  async unassignUserFromTeam(userId: string): Promise<IUser> {
     throw new Error('MemStorage is a stub - use MongoStorage instead');
   }
 


### PR DESCRIPTION
Enable supervisors to add and remove members from Field Teams via a new "Manage Members" dialog.

Supervisors previously lacked a direct interface to manage team membership, requiring an administrator for such changes. This PR introduces a dedicated UI and backend support to empower supervisors with direct control over their team's roster.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d84b30f-8241-4062-a266-8a1ddff3270d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d84b30f-8241-4062-a266-8a1ddff3270d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

