### PR TITLE
Debug team member assignment error

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -469,8 +469,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const fieldUsers = await storage.getAllFieldUsers();
       // Remove passwords from response
-      const usersResponse = fieldUsers.map((user) => {
-        const { password, ...userWithoutPassword } = user;
+      const usersResponse = fieldUsers.map((user: any) => {
+        const plainUser = typeof user?.toObject === "function" ? user.toObject() : user;
+        const { password, ...userWithoutPassword } = plainUser;
         return userWithoutPassword;
       });
       res.json(usersResponse);
@@ -492,16 +493,17 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // For now, we'll fetch by trying common supervisor usernames or IDs
       try {
         const supervisor = await storage.getUserByUsername("supervisor");
-        if (supervisor && !allUsers.find(u => u._id.toString() === supervisor._id.toString())) {
-          allUsers.push(supervisor);
+        if (supervisor && !allUsers.find(u => (u as any)._id.toString() === supervisor._id.toString())) {
+          allUsers.push(supervisor as any);
         }
       } catch (e) {
         // Supervisor might not exist or have different username
       }
       
       // Remove passwords from response
-      const usersResponse = allUsers.map((user) => {
-        const { password, ...userWithoutPassword } = user;
+      const usersResponse = allUsers.map((user: any) => {
+        const plainUser = typeof user?.toObject === "function" ? user.toObject() : user;
+        const { password, ...userWithoutPassword } = plainUser;
         return userWithoutPassword;
       });
       res.json(usersResponse);
@@ -1657,8 +1659,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
           return res.status(400).json({ message: "Invalid team ID format" });
         }
 
-        const updatedUser = await storage.assignUserToTeam(userId, teamId);
-        const { password, ...userResponse } = updatedUser;
+        const updatedUser: any = await storage.assignUserToTeam(userId, teamId);
+        const plainUser = typeof updatedUser?.toObject === "function" ? updatedUser.toObject() : updatedUser;
+        const { password, ...userResponse } = plainUser;
 
         res.json(userResponse);
       } catch (error) {
@@ -1675,8 +1678,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
     async (req, res) => {
       try {
         const userId = req.params.id;
-        const updatedUser = await storage.unassignUserFromTeam(userId);
-        const { password, ...userResponse } = updatedUser as any;
+        const updatedUser: any = await storage.unassignUserFromTeam(userId);
+        const plainUser = typeof updatedUser?.toObject === "function" ? updatedUser.toObject() : updatedUser;
+        const { password, ...userResponse } = plainUser;
         res.json(userResponse);
       } catch (error) {
         console.error("Unassign user from team error:", error);


### PR DESCRIPTION
Convert Mongoose documents to plain objects before stripping fields to preserve `_id` and fix `undefined` user IDs in API requests.

The `assign-team` API call was failing with a 400 Bad Request because the `userId` in the URL was `undefined`. This occurred because backend endpoints like `/api/users/field` were returning Mongoose documents and attempting to strip the `password` field using object destructuring directly on the document instance. This process inadvertently caused the `_id` property to be lost, resulting in the frontend receiving user objects without an `_id`. By converting Mongoose documents to plain JavaScript objects using `toObject()` before destructuring, we ensure that `_id` is consistently present, resolving the `undefined` `userId` issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dd3418f-6dbf-4d64-8f11-7609f1737318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6dd3418f-6dbf-4d64-8f11-7609f1737318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

