### PR TITLE
Investigate image loading failure

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,4 +28,18 @@ export default defineConfig({
     outDir: path.resolve(import.meta.dirname, "dist/"),
     emptyOutDir: true,
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:5000",
+        changeOrigin: true,
+        secure: false,
+      },
+      "/uploads": {
+        target: "http://localhost:5000",
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 });


### PR DESCRIPTION
Add Vite dev proxy for `/api` and `/uploads` to enable image loading when running the client standalone.

Previously, when the client was served directly by the Vite dev server (e.g., `npm run dev` and accessing the Vite port directly), requests for `/uploads/...` (where images are served) would result in 404s. This proxy ensures that these requests are correctly forwarded to the backend server running on port 5000, allowing images to load in all development environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-28a30848-ef70-438f-a0a2-19ad1e67ebec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28a30848-ef70-438f-a0a2-19ad1e67ebec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

