### PR TITLE
Fix boundary label showing unassigned

### DIFF
--- a/client/src/lib/OpenLayersMap.tsx
+++ b/client/src/lib/OpenLayersMap.tsx
@@ -1418,18 +1418,22 @@ const OpenLayersMap = ({
               type: 'boundary-label'
             });
             
-            // Find assigned team with robust ObjectId comparison
-            const assignedTeam = allTeams.find(team => {
-              if (!boundary.assignedTo || !team._id) return false;
-              
-              // Convert both IDs to strings for reliable comparison
-              const teamIdStr = String(team._id);
-              const assignedIdStr = String(boundary.assignedTo);
-              
-              return teamIdStr === assignedIdStr;
-            });
-            
-            const teamName = assignedTeam ? assignedTeam.name : "Unassigned";
+            // Determine team name handling both populated and raw ObjectId cases
+            let teamName = "Unassigned";
+            const assigned = (boundary as any).assignedTo;
+            if (assigned) {
+              // If populated document, prefer its name directly
+              if (typeof assigned === 'object') {
+                teamName = assigned.name || assigned.username || 'Unknown Team';
+              } else {
+                // Fallback: find in allTeams by matching IDs as strings
+                const assignedTeam = allTeams.find(team => {
+                  if (!team || !team._id) return false;
+                  return String(team._id) === String(assigned);
+                });
+                teamName = assignedTeam ? assignedTeam.name : 'Unknown Team';
+              }
+            }
             
             labelFeature.set('labelText', `${boundary.name}\nAssigned to: ${teamName}`);
             source.addFeature(labelFeature);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1339,9 +1339,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
       } else {
         // Field users can only see boundaries assigned to their team
         const allBoundaries = await storage.getAllBoundaries();
-        boundaries = allBoundaries.filter(
-          boundary => boundary.assignedTo?.toString() === user.teamId?.toString()
-        );
+        boundaries = allBoundaries.filter((boundary: any) => {
+          const assigned = boundary?.assignedTo;
+          if (!assigned || !user.teamId) return false;
+          // Handle both populated doc and raw ObjectId/string
+          const assignedId = typeof assigned === 'object' ? assigned._id?.toString?.() : assigned?.toString?.();
+          return assignedId === user.teamId.toString();
+        });
       }
       
       res.json(boundaries);


### PR DESCRIPTION
Fix boundary labels showing "Unassigned" after assignment and ensure correct server-side filtering for field users.

The client-side map rendering logic was not correctly parsing the `assignedTo` field when it was returned as a populated object, causing the label to default to "Unassigned". Additionally, the server-side boundary filtering for field users also needed to be updated to handle `assignedTo` being a populated object.

---
<a href="https://cursor.com/background-agent?bcId=bc-d00ae27d-69d3-49b6-8a83-adea08049e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d00ae27d-69d3-49b6-8a83-adea08049e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

