### PR TITLE
Fix disappearing boundary drawing

### DIFF
--- a/client/src/lib/OpenLayersMap.tsx
+++ b/client/src/lib/OpenLayersMap.tsx
@@ -1122,8 +1122,14 @@ const OpenLayersMap = ({
       drawInteractionRef.current = null;
     }
 
-    // Remove existing draw layer
-    if (drawLayerRef.current) {
+    // Remove existing draw layer ONLY when entering a new drawing mode.
+    // This preserves the last drawn geometry (e.g., polygon) until explicitly cleared via clearDrawnPolygon.
+    const willCreateNewDrawLayer =
+      (drawingMode && !!onPolygonCreated) ||
+      (pointSelectionMode && !!onMapClick) ||
+      (lineDrawingMode && !!onLineCreated);
+
+    if (willCreateNewDrawLayer && drawLayerRef.current) {
       mapRef.current.removeLayer(drawLayerRef.current);
       drawLayerRef.current = null;
     }


### PR DESCRIPTION
Prevent the draw layer from being removed prematurely to fix an issue where the first drawn polygon disappears.

The previous logic in `OpenLayersMap.tsx` unconditionally removed the draw layer when the drawing effect re-ran, which occurred after the first polygon was completed, causing it to disappear. This change ensures the layer persists until a new drawing mode is activated or explicitly cleared.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e4fb5ca-a502-40c3-95c7-a4e282e5e4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e4fb5ca-a502-40c3-95c7-a4e282e5e4a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

