### PR TITLE
Fix user dashboard tower placement error

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -860,9 +860,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
         // If supervisor is creating, skip boundary restriction
         // Get all boundaries assigned to the user's team
         const allBoundaries = await storage.getAllBoundaries();
-        const assignedBoundaries = allBoundaries.filter(boundary => 
-          boundary.assignedTo?.toString() === user.teamId?.toString()
-        );
+        // Handle both populated `assignedTo` objects and raw ObjectId/string values
+        const assignedBoundaries = allBoundaries.filter((boundary: any) => {
+          const assigned = boundary?.assignedTo;
+          if (!assigned || !user.teamId) return false;
+          const assignedId = typeof assigned === 'object' ? assigned._id?.toString?.() : assigned?.toString?.();
+          return assignedId === user.teamId.toString();
+        });
         
         if (assignedBoundaries.length === 0) {
           return res.status(403).json({ message: "No boundaries assigned to your team" });


### PR DESCRIPTION
Fix "No boundaries assigned to your team" error by correctly matching team-assigned boundaries.

The server's feature creation handler incorrectly compared `boundary.assignedTo` (which could be a populated object) directly against the team ID string, leading to a false "No boundaries assigned to your team" error for field users attempting to create features within their assigned boundaries. This PR updates the comparison logic to safely extract the assigned team's ID, whether `assignedTo` is an object or a raw ID, ensuring correct authorization.

---
<a href="https://cursor.com/background-agent?bcId=bc-64569d46-1b7f-4b84-8342-780a84d53570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64569d46-1b7f-4b84-8342-780a84d53570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

